### PR TITLE
Widen "publish transaction" modal

### DIFF
--- a/src/components/transactions/EditTransactionModal/AccountingLines.tsx
+++ b/src/components/transactions/EditTransactionModal/AccountingLines.tsx
@@ -39,7 +39,7 @@ export const AccountingLines = ({
                 <div className="flex items-center text-sm text-[#171A1F] font-bold py-4">
                     Transaction Value
                 </div>
-                <div className="grid grid-cols-[1fr,1.1fr,1fr,28px] gap-1">
+                <div className="grid grid-cols-[1fr,2fr,1fr,28px] gap-1">
                     <div className="flex justify-center items-center text-sm text-[#171A1F] font-bold py-4">
                         Type
                     </div>
@@ -54,16 +54,16 @@ export const AccountingLines = ({
                             className="relative top-3 right-0.5 w-7 h-8 flex items-center justify-center"
                             onClick={(): void => handleAddNewLine()}
                         >
-                            <CirclePlus className="w-6 h-6"/>
+                            <CirclePlus className="w-6 h-6" />
                         </button>
                     )}
                 </div>
             </div>
             <div className="grid grid-cols-[2fr,4.1fr] mt-3 gap-1 relative">
                 <div>
-                  <span className="bg-[#F3F4F6] text-sm text-[#565D6D] rounded-2xl py-2 px-7">
-                    {`${amount} ${symbolAmount}`}
-                  </span>
+                    <span className="bg-[#F3F4F6] text-sm text-[#565D6D] rounded-2xl py-2 px-7">
+                        {`${amount} ${symbolAmount}`}
+                    </span>
                 </div>
                 <div className="relative space-y-3">
                     {accountingLines && accountingLines.map((accountingLine, idx) => (

--- a/src/components/transactions/EditTransactionModal/BlockchainFee.tsx
+++ b/src/components/transactions/EditTransactionModal/BlockchainFee.tsx
@@ -12,7 +12,7 @@ const BlockchainFee = ({ transaction }: Props): React.JSX.Element => {
         <div className="flex items-center text-sm text-[#171A1F] font-bold pr-1 py-4">
           Blokchain Fee
         </div>
-        <div className="grid grid-cols-[1fr,1.1fr,1fr,28px] gap-1">
+        <div className="grid grid-cols-[1fr,2fr,1fr,28px] gap-1">
           <div className="flex justify-center items-center text-sm text-[#171A1F] font-bold py-4" />
           <div className="flex justify-center items-center text-sm text-[#565D6D] font-bold py-4">
             Choose expense
@@ -33,7 +33,7 @@ const BlockchainFee = ({ transaction }: Props): React.JSX.Element => {
                 }`}
               </span>
             </div>
-            <div className="grid grid-cols-[1fr,1.1fr,1fr,28px] gap-1">
+            <div className="grid grid-cols-[1fr,2fr,1fr,28px] gap-1">
               <div className="flex justify-center items-center">
                 <span className="bg-[#F3F4F6] text-sm text-[#565D6D] rounded-2xl py-2 px-2 w-full text-center">
                   Fee

--- a/src/components/transactions/EditTransactionModal/CollectionLine.tsx
+++ b/src/components/transactions/EditTransactionModal/CollectionLine.tsx
@@ -86,7 +86,7 @@ const CollectionLine = ({
       default:
         throw new Error('Illegal accountType option');
     }
-  }, [enableQuickbooksDataFetching, colIdx, accountingType, accounts, bills, invoices, items, currencyMappings, transaction.tokenIncoming, transaction.tokenOutgoing, token]);
+  }, [enableCurrencyMappingsFetching, enableQuickbooksDataFetching, colIdx, accountingType, accounts, bills, invoices, items, currencyMappings, transaction.tokenIncoming, transaction.tokenOutgoing, token]);
 
   const handleChangeAccountingType = (selectedAccountingType: AccountingTransactionType | null): void => {
     const updatedTransaction = {...accountingLine, ...(selectedAccountingType ? {accountingType: selectedAccountingType} : {})};
@@ -142,7 +142,7 @@ const CollectionLine = ({
   }
 
   return (
-    <div className="grid grid-cols-[1fr,1.1fr,1fr,28px] gap-1">
+    <div className="grid grid-cols-[1fr,2fr,1fr,28px] gap-1">
       <div className="flex items-center">
         {transaction.status === 'Published' || isSwap ? (
           <span className="bg-[#F3F4F6] text-sm text-[#565D6D] rounded-2xl py-2 px-3 w-full">

--- a/src/components/transactions/EditTransactionModal/index.tsx
+++ b/src/components/transactions/EditTransactionModal/index.tsx
@@ -35,18 +35,42 @@ interface Props {
 
 const initializeAccountingLinesIncoming = (transaction: TransactionProps): AccountingLine[] => {
   if (transaction.direction === Direction.Swap) {
-    const accountingLinesSwapIn = transaction?.accountingLines?.filter(accountingLine => accountingLine.accountingType && AccountingTransactionType.Swap === accountingLine.accountingType) || [];
-    if (!accountingLinesSwapIn || accountingLinesSwapIn.length === 0) return [{accountingType: AccountingTransactionType.Swap}];
-    else return accountingLinesSwapIn;
-  } else return transaction?.accountingLines?.filter(accountingLine => accountingLine.accountingType && [AccountingTransactionType.Income, AccountingTransactionType.Invoice].includes(accountingLine.accountingType)) || [];
+    const accountingLinesSwapIn = transaction?.accountingLines?.filter(
+      accountingLine => accountingLine?.accountingType === AccountingTransactionType.Swap
+    ) || [];
+
+    return accountingLinesSwapIn.length > 0
+      ? accountingLinesSwapIn
+      : [{ accountingType: AccountingTransactionType.Swap }];
+  }
+
+  return transaction?.accountingLines?.filter(
+    accountingLine => accountingLine.accountingType
+      && [
+        AccountingTransactionType.Income,
+        AccountingTransactionType.Invoice
+      ].includes(accountingLine.accountingType)
+    ) || [{ accountingType: AccountingTransactionType.Income }];
 };
 
 const initializeAccountingLinesOutgoing = (transaction: TransactionProps): AccountingLine[] => {
   if (transaction.direction === Direction.Swap) {
-    const accountingLinesSwapOut = transaction?.accountingLines?.filter(accountingLine => accountingLine.accountingType && AccountingTransactionType.Swap === accountingLine.accountingType) || [];
-    if (!accountingLinesSwapOut || accountingLinesSwapOut.length === 0) return [{accountingType: AccountingTransactionType.Swap}];
-    else return accountingLinesSwapOut;
-  } else return transaction?.accountingLines?.filter(accountingLine => accountingLine.accountingType && [AccountingTransactionType.Expense, AccountingTransactionType.Bill].includes(accountingLine.accountingType)) || [];
+    const accountingLinesSwapOut = transaction?.accountingLines?.filter(
+      accountingLine => accountingLine?.accountingType === AccountingTransactionType.Swap
+    ) || [];
+
+    return accountingLinesSwapOut.length > 0
+      ? accountingLinesSwapOut
+      : [{accountingType: AccountingTransactionType.Swap}];
+  }
+
+  return transaction?.accountingLines?.filter(
+    accountingLine => accountingLine.accountingType
+      && [
+        AccountingTransactionType.Expense,
+        AccountingTransactionType.Bill
+      ].includes(accountingLine.accountingType)
+    ) || [{ accountingType: AccountingTransactionType.Expense }];
 };
 
 const EditTransactionModal = ({
@@ -54,8 +78,14 @@ const EditTransactionModal = ({
   transaction,
   nonSetMappings,
 }: Props): React.JSX.Element => {
-  const [accountingLinesIncoming, setAccountingLinesIncoming] = useState<AccountingLine[]>(initializeAccountingLinesIncoming(transaction as TransactionProps));
-  const [accountingLinesOutgoing, setAccountingLinesOutgoing] = useState<AccountingLine[]>(initializeAccountingLinesOutgoing(transaction as TransactionProps));
+  const [accountingLinesIncoming, setAccountingLinesIncoming] = useState<AccountingLine[]>(
+    initializeAccountingLinesIncoming(transaction as TransactionProps)
+  );
+
+  const [accountingLinesOutgoing, setAccountingLinesOutgoing] = useState<AccountingLine[]>(
+    initializeAccountingLinesOutgoing(transaction as TransactionProps)
+  );
+
   const showMismatchAmount = useBoolean(false);
   const publishTransactionMutation = useMutationPublishTransaction();
 
@@ -67,6 +97,7 @@ const EditTransactionModal = ({
         reference: "USD",
       },
     };
+
     setAccountingLinesIncoming([...accountingLinesIncoming, newLine]);
   };
 
@@ -78,6 +109,7 @@ const EditTransactionModal = ({
         reference: "USD",
       },
     };
+
     setAccountingLinesOutgoing([...accountingLinesOutgoing, newLine]);
   };
 
@@ -107,15 +139,36 @@ const EditTransactionModal = ({
     showMismatchAmount.onFalse();
   }, [showMismatchAmount]);
 
-  const nonMappedTokensOfTransaction = useMemo((): Token[] => {
-    const nonMappedTokens = nonSetMappings.filter(tokenMapping => tokenMapping.token.chain === transaction?.tokenIncoming?.chain || tokenMapping.token.chain === transaction?.tokenOutgoing?.chain)
+  const nonMappedTokensOfTransaction = useMemo(
+    (): Token[] => {
+      const nonMappedTokens = nonSetMappings
+        .filter(
+          tokenMapping => tokenMapping.token.chain === transaction?.tokenIncoming?.chain
+            || tokenMapping.token.chain === transaction?.tokenOutgoing?.chain
+          )
         .map(tokenMapping => tokenMapping.token);
-    if (transaction?.direction === Direction.Incoming) return nonMappedTokens.filter(token => keyFormatTransaction(token) === keyFormatTransaction(transaction?.tokenIncoming as Token));
-    else if (transaction?.direction === Direction.Outgoing) return nonMappedTokens.filter(token => keyFormatTransaction(token) === keyFormatTransaction(transaction?.tokenOutgoing as Token));
-    else if (transaction?.direction === Direction.Swap) {
-      return nonMappedTokens.filter(token => keyFormatTransaction(token) === keyFormatTransaction(transaction?.tokenIncoming as Token) || keyFormatTransaction(token) === keyFormatTransaction(transaction?.tokenOutgoing as Token));
-    } else return [];
-  }, [nonSetMappings, transaction]);
+
+      switch (transaction?.direction) {
+        case Direction.Incoming:
+          return nonMappedTokens.filter(
+            token => keyFormatTransaction(token) ===
+              keyFormatTransaction(transaction?.tokenIncoming as Token));
+        case Direction.Outgoing:
+          return nonMappedTokens.filter(
+            token => keyFormatTransaction(token) ===
+              keyFormatTransaction(transaction?.tokenOutgoing as Token));
+        case Direction.Swap:
+          return nonMappedTokens.filter(
+            token => keyFormatTransaction(token) ===
+                keyFormatTransaction(transaction?.tokenIncoming as Token)
+              || keyFormatTransaction(token) ===
+                keyFormatTransaction(transaction?.tokenOutgoing as Token));
+        default:
+          return [];
+      }
+    },
+    [nonSetMappings, transaction]
+  );
 
   const isSumMismatchedIncoming = useMemo((): boolean => {
     if ([Direction.Incoming, Direction.Swap].includes(transaction?.direction as Direction)) {
@@ -206,7 +259,7 @@ const EditTransactionModal = ({
 
   return (
     <RightModal
-      modalClassNames="max-w-2xl max-h-[calc(100%-54px)]"
+      modalClassNames="max-w-4xl max-h-[calc(100%-54px)]"
       show={editTransaction.value}
       closeModal={editTransaction.onFalse}
     >
@@ -218,7 +271,7 @@ const EditTransactionModal = ({
             />
             <CommonWarningAlert
               shouldShow={showMismatchAmount.value}
-              message="The Total amount value if too much different from transaction amount. Please regulate the transaction values"
+              message="The total amount value is too different from the transaction amount. Please correct the transaction values"
               onClose={closeWarningSumMismatch}
             />
 


### PR DESCRIPTION
To make debugging easier (and also improve UX), I made the modal for transaction publishing wider, in particular the part where the user selects the income or invoice the txn refers to.