### PR TITLE
Suggest entries that match a transaction

### DIFF
--- a/src/components/reports/create/reconciliation/CreateReconciliationReport.tsx
+++ b/src/components/reports/create/reconciliation/CreateReconciliationReport.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import classNames from "classnames";
 import { useRouter } from "next/router";
 import { toast } from "react-toastify";
@@ -86,6 +86,15 @@ export const CreateReconciliationReport = (): React.JSX.Element => {
     setReconciliations(reconciliations.concat(newReconciliation))
   };
 
+  // These are precomputed rather than executing N times the same filtering
+  const incomingEntries = useMemo(() => unreconciledEntries.filter(
+    entry => entry.direction === Direction.Incoming
+  ), [unreconciledEntries]);
+
+  const outgoingEntries = useMemo(() => unreconciledEntries.filter(
+    entry => entry.direction === Direction.Outgoing
+  ), [unreconciledEntries]);
+
   if (transactionsAreLoading || entriesAreLoading) {
     return (
       <div className="flex justify-center mt-8">
@@ -97,15 +106,6 @@ export const CreateReconciliationReport = (): React.JSX.Element => {
   if (transactionsAreError || entriesAreError) {
     return <ServerError />;
   }
-
-  // These are precomputed rather than executing N times the same filtering
-  const incomingEntries = unreconciledEntries.filter(
-    entry => entry.direction === Direction.Incoming
-  );
-
-  const outgoingEntries = unreconciledEntries.filter(
-    entry => entry.direction === Direction.Outgoing
-  )
 
   const filterEntriesByDirection = (
     transaction: TransactionProps

--- a/src/components/reports/create/reconciliation/EntriesSelector.tsx
+++ b/src/components/reports/create/reconciliation/EntriesSelector.tsx
@@ -1,30 +1,86 @@
+import { Dispatch, SetStateAction, useEffect } from "react";
+import { usePickEntries } from "@/hooks/reports/usePickEntries";
+import { calculateTransactionAmount, sumEntryAmounts } from "@/lib/helpers";
+import { TransactionProps } from "@/services/transactions";
 import { IntegrationTransactionEntry, ReconciliationEntrySources } from "@/services/reports/reconciliation";
+import { MatchReconciliationEntries } from "./MatchReconciliationEntries";
 import { PickReconciliationEntries } from "./PickReconciliationEntries";
 
 interface Props {
-  transactionAmount: number;
-  entriesAmount: number;
   entriesSource: ReconciliationEntrySources;
   isReconcilable: boolean;
-  entriesToReconcile: IntegrationTransactionEntry[];
+  matchingEntries: IntegrationTransactionEntry[];
+  setEntriesToReconcile: Dispatch<SetStateAction<IntegrationTransactionEntry[]>>;
+  setIsReconcilable: Dispatch<SetStateAction<boolean>>;
+  setUnreconciledEntries: Dispatch<SetStateAction<IntegrationTransactionEntry[]>>;
+  transaction: TransactionProps;
   unreconciledEntries: IntegrationTransactionEntry[];
-  removeEntry: (entry: string) => void;
-  addEntry: (entry: string) => void;
 }
 
-export const EntriesSelector = (props: Props): React.JSX.Element => {
-  const { entriesSource, ...drilledProps } = props;
+export const EntriesSelector = ({
+  entriesSource,
+  isReconcilable,
+  matchingEntries,
+  setEntriesToReconcile,
+  setIsReconcilable,
+  setUnreconciledEntries,
+  transaction,
+  unreconciledEntries,
+}: Props): React.JSX.Element => {
+  const {
+    checkIfReconcilable,
+    pickedEntries,
+    pickedEntriesAmount,
+    pickEntry,
+    setPickedEntriesAmount,
+    unpickEntry,
+  } = usePickEntries(
+    { setIsReconcilable, setUnreconciledEntries, transaction, unreconciledEntries }
+  );
+
+  useEffect(
+    () => {
+      if (entriesSource === ReconciliationEntrySources.Match) {
+        setEntriesToReconcile(matchingEntries);
+        const matchingTotalAmount = sumEntryAmounts(matchingEntries);
+        const transactionAmount = calculateTransactionAmount(transaction);
+        setIsReconcilable(matchingTotalAmount === transactionAmount);
+      } else if (entriesSource === ReconciliationEntrySources.Pick) {
+        setEntriesToReconcile(pickedEntries);
+        setPickedEntriesAmount(sumEntryAmounts(pickedEntries));
+        checkIfReconcilable();
+      }
+    }, [
+      checkIfReconcilable,
+      entriesSource,
+      matchingEntries,
+      pickedEntries,
+      setEntriesToReconcile,
+      setIsReconcilable,
+      setPickedEntriesAmount,
+      transaction,
+    ]
+  );
 
   switch (entriesSource) {
+    case ReconciliationEntrySources.Match:
+      return <MatchReconciliationEntries
+        matchingEntries={matchingEntries}
+        transaction={transaction}
+      />;
     case ReconciliationEntrySources.Pick:
-      return <PickReconciliationEntries {...drilledProps} />;
+      return <PickReconciliationEntries
+        isReconcilable={isReconcilable}
+        pickEntry={pickEntry}
+        pickedEntries={pickedEntries}
+        pickedEntriesAmount={pickedEntriesAmount}
+        transaction={transaction}
+        unpickEntry={unpickEntry}
+        unreconciledEntries={unreconciledEntries}
+      />;
     case ReconciliationEntrySources.Create:
       return <div className="mt-6">
         Placeholder for a component to create an Entry (pending the backend)
-      </div>;
-    default:
-      return <div className="mt-6">
-        Placeholder for a component to suggest an Entry matching the transaction (pending the backend)
       </div>;
   }
 };

--- a/src/components/reports/create/reconciliation/MatchReconciliationEntries.tsx
+++ b/src/components/reports/create/reconciliation/MatchReconciliationEntries.tsx
@@ -1,0 +1,44 @@
+import classNames from "classnames";
+import { IntegrationTransactionEntry } from "@/services/reports/reconciliation";
+import { TransactionProps } from "@/services/transactions";
+import { calculateTransactionAmount, sumEntryAmounts } from "@/lib/helpers";
+import { ReconciliationEntry } from "@/components/reports/reconciliation/ReconciliationEntry";
+
+interface Props {
+  matchingEntries: IntegrationTransactionEntry[];
+  transaction: TransactionProps;
+}
+
+export const MatchReconciliationEntries = ({
+  matchingEntries,
+  transaction
+}: Props): React.JSX.Element => {
+  if (matchingEntries.length === 0) {
+    return <div className="mt-6">
+      <p>No entries were found matching this transaction. Please pick existing entries or create new ones.</p>
+    </div>;
+  }
+
+  const matchingEntriesAmount = sumEntryAmounts(matchingEntries);
+  const transactionAmount = calculateTransactionAmount(transaction);
+  const discrepancy = transactionAmount - matchingEntriesAmount;
+  const margin = Math.abs(100 * discrepancy / transactionAmount);
+
+  return <div className={classNames("w-full mt-6 p-3", margin < 5 && "bg-[#4ADDB6]")}>
+    <p>Amount left to reconcile: {discrepancy.toFixed(6)} ({margin.toFixed(1)}%)</p>
+    <div className="flex-1 border border-gray-500 px-4 py-2">
+      <h5 className="pb-4">
+        The {
+          matchingEntries.length === 1
+            ? 'entry below matches'
+            : matchingEntries.length + ' entries below match'
+        } this transaction&apos;s ID
+      </h5>
+      <ul className="mt-2 w-full divide-y-4">
+        {matchingEntries.map(entry =>
+          <ReconciliationEntry key={entry.entryId} entry={entry} />
+        )}
+      </ul>
+    </div>
+  </div>;
+};

--- a/src/components/reports/create/reconciliation/PickReconciliationEntries.tsx
+++ b/src/components/reports/create/reconciliation/PickReconciliationEntries.tsx
@@ -1,49 +1,52 @@
 import classNames from "classnames";
+import { calculateTransactionAmount } from "@/lib/helpers";
+import { TransactionProps } from "@/services/transactions";
 import { IntegrationTransactionEntry } from "@/services/reports/reconciliation";
 import { UnreconciledEntries } from "./UnreconciledEntries";
 import { ReconciliationEntry } from "@/components/reports/reconciliation/ReconciliationEntry";
 
 interface Props {
-  transactionAmount: number;
-  entriesAmount: number;
   isReconcilable: boolean;
-  entriesToReconcile: IntegrationTransactionEntry[];
+  pickedEntries: IntegrationTransactionEntry[];
+  pickedEntriesAmount: number;
+  pickEntry: (entry: string) => void;
+  unpickEntry: (entry: string) => void;
   unreconciledEntries: IntegrationTransactionEntry[];
-  removeEntry: (entry: string) => void;
-  addEntry: (entry: string) => void;
+  transaction: TransactionProps;
 }
 
 export const PickReconciliationEntries = ({
-  transactionAmount,
-  entriesAmount,
   isReconcilable,
-  entriesToReconcile,
+  pickedEntries,
+  pickedEntriesAmount,
+  pickEntry,
+  unpickEntry,
   unreconciledEntries,
-  removeEntry,
-  addEntry,
+  transaction,
 }: Props): React.JSX.Element => {
-  const discrepancy = transactionAmount - entriesAmount;
+  const transactionAmount = calculateTransactionAmount(transaction);
+  const discrepancy = transactionAmount - pickedEntriesAmount;
   const margin = Math.abs(100 * discrepancy / transactionAmount);
 
   return (
     <>
       <ul className={classNames("w-full divide-y-4 mt-6 p-3", isReconcilable && "bg-[#4ADDB6]")}>
         <p>Amount left to reconcile: {discrepancy.toFixed(6)} ({margin.toFixed(1)}%)</p>
-        {entriesToReconcile.length ?
-          entriesToReconcile.map((entry) =>
+        {pickedEntries.length ?
+          pickedEntries.map((entry) =>
             <ReconciliationEntry
               key={entry.entryId}
               entry={entry}
-              moveEntry={removeEntry}
+              moveEntry={unpickEntry}
               buttonText={"Remove"}
             />) :
           "Please select some entries below."
         }
       </ul>
       <UnreconciledEntries
-        entries={unreconciledEntries.filter((entry) => !entriesToReconcile.includes(entry))}
-        moveEntry={addEntry}
+        entries={unreconciledEntries.filter((entry) => !pickedEntries.includes(entry))}
+        moveEntry={pickEntry}
       />
     </>
   );
-}
+};

--- a/src/components/reports/create/reconciliation/ReconciliationTransaction.tsx
+++ b/src/components/reports/create/reconciliation/ReconciliationTransaction.tsx
@@ -1,74 +1,26 @@
-import { Dispatch, SetStateAction, useCallback, useEffect, useState } from "react";
+import { type Dispatch, type SetStateAction, useState } from "react";
 import classNames from "classnames";
-import { doFloatsMatch, parseAmount } from "@/lib/helpers";
-import { Direction, TransactionProps } from "@/services/transactions";
+import { type TransactionProps } from "@/services/transactions";
+import { type ReconciliationReportItem, type IntegrationTransactionEntry } from "@/services/reports/reconciliation";
 import { ChainTransactionForReconciliation } from "@/components/reports/reconciliation/ChainTransactionForReconciliation";
-import { ReconciliationReportItem, IntegrationTransactionEntry } from "@/services/reports/reconciliation";
-import { ReconciliationTransactionEntries } from "./ReconciliationTransactionEntries";
+import { ReconciliationTransactionEntries } from "@/components/reports/create/reconciliation/ReconciliationTransactionEntries";
 
 interface Props {
-  transaction: TransactionProps;
   addReconciliationToReport: (newReconciliation: ReconciliationReportItem) => void;
-  unreconciledEntries: IntegrationTransactionEntry[];
   setUnreconciledEntries: Dispatch<SetStateAction<IntegrationTransactionEntry[]>>;
+  transaction: TransactionProps;
+  unreconciledEntries: IntegrationTransactionEntry[];
 }
 
 export const ReconciliationTransaction = (
   {
-    transaction,
     addReconciliationToReport,
+    setUnreconciledEntries,
+    transaction,
     unreconciledEntries,
-    setUnreconciledEntries
   }: Props): React.JSX.Element => {
-
-  const [entriesToReconcile, setEntriesToReconcile] = useState([] as IntegrationTransactionEntry[]);
   const [isReconcilable, setIsReconcilable] = useState(false);
-  const [entriesAmount, setEntriesAmount] = useState(0.0);
-
-  const amountIncoming = parseAmount(transaction.amountIncoming);
-  const amountOutgoing = parseAmount(transaction.amountOutgoing);
-  const transactionAmount = Math.abs(amountIncoming - amountOutgoing);
-
-  const checkIfReconcilableCallback = (): void => {
-    const hasIncoming = !doFloatsMatch(amountIncoming, 0.0);
-    const hasOutgoing = !doFloatsMatch(amountOutgoing, 0.0);
-    const tolerance = 0.05;
-    const isDiscrepancyTolerable = Math.abs(
-      (transactionAmount - entriesAmount) / transactionAmount
-    ) <= tolerance;
-
-    switch (transaction.direction) {
-      case Direction.Incoming:
-        setIsReconcilable(isDiscrepancyTolerable);
-        break;
-      case Direction.Outgoing:
-        setIsReconcilable(isDiscrepancyTolerable);
-        break;
-      case Direction.Swap:
-        setIsReconcilable(isDiscrepancyTolerable && hasIncoming && hasOutgoing);
-        break;
-      default:
-        setIsReconcilable(false);
-        break;
-    }
-  };
-
-  const checkIfReconcilable = useCallback(
-    checkIfReconcilableCallback,
-    [amountIncoming, amountOutgoing, entriesAmount, transaction.direction, transactionAmount]
-  );
-
-  const recalculateEntriesAmount = (): void => {
-    const sumAmounts = (
-      total: number,
-      entry: IntegrationTransactionEntry
-    ): number => total + parseAmount(entry.reconvertedAmount);
-
-    setEntriesAmount(entriesToReconcile.reduce(sumAmounts, 0));
-    checkIfReconcilable();
-  };
-
-  useEffect(recalculateEntriesAmount, [entriesToReconcile, checkIfReconcilable]);
+  const [entriesToReconcile, setEntriesToReconcile] = useState([] as IntegrationTransactionEntry[]);
 
   const reconcileTransaction = (): void => {
     const { atomicTransactionId, workspaceIdChainAddress } = transaction;
@@ -87,23 +39,6 @@ export const ReconciliationTransaction = (
     addReconciliationToReport(newReconciliation);
   };
 
-  const addEntry = (clickedEntryId: string): void => {
-    const clickedEntry = unreconciledEntries.find(
-      entry => entry.entryId === clickedEntryId
-    ) as IntegrationTransactionEntry;
-    setUnreconciledEntries(unreconciledEntries.filter(entry => entry !== clickedEntry));
-    setEntriesToReconcile(entriesToReconcile.concat(clickedEntry));
-  };
-
-  const removeEntry = (clickedEntryId: string): void => {
-    const clickedEntry = entriesToReconcile.find(
-      entry => entry.entryId === clickedEntryId
-    ) as IntegrationTransactionEntry;
-
-    setUnreconciledEntries(unreconciledEntries.concat(clickedEntry));
-    setEntriesToReconcile(entriesToReconcile.filter(entry => entry !== clickedEntry));
-  }
-
   return (
     <li className="block mb-2">
       <div className="flex outline-none py-1 px-3 w-full rounded-md col-span-12">
@@ -119,13 +54,12 @@ export const ReconciliationTransaction = (
         </button>
         <div className="flex-1 border border-gray-500">
           <ReconciliationTransactionEntries
-            transactionAmount={transactionAmount}
-            entriesAmount={entriesAmount}
             isReconcilable={isReconcilable}
-            entriesToReconcile={entriesToReconcile}
+            setEntriesToReconcile={setEntriesToReconcile}
+            setIsReconcilable={setIsReconcilable}
+            setUnreconciledEntries={setUnreconciledEntries}
+            transaction={transaction}
             unreconciledEntries={unreconciledEntries}
-            removeEntry={removeEntry}
-            addEntry={addEntry}
           />
         </div>
       </div>

--- a/src/components/reports/create/reconciliation/ReconciliationTransactionEntries.tsx
+++ b/src/components/reports/create/reconciliation/ReconciliationTransactionEntries.tsx
@@ -1,21 +1,31 @@
-import { useState } from "react";
-import { IntegrationTransactionEntry, ReconciliationEntrySources } from "@/services/reports/reconciliation";
-import { EntriesSelector } from "./EntriesSelector";
-import { EntrySourceButtons } from "./EntrySourceButtons";
+import { Dispatch, SetStateAction, useState } from "react";
+import { type IntegrationTransactionEntry, ReconciliationEntrySources } from "@/services/reports/reconciliation";
+import { TransactionProps } from "@/services/transactions";
+import { EntriesSelector } from "@/components/reports/create/reconciliation/EntriesSelector";
+import { EntrySourceButtons } from "@/components/reports/create/reconciliation/EntrySourceButtons";
 
 interface Props {
-  transactionAmount: number;
-  entriesAmount: number;
   isReconcilable: boolean;
-  entriesToReconcile: IntegrationTransactionEntry[];
+  setEntriesToReconcile: Dispatch<SetStateAction<IntegrationTransactionEntry[]>>;
+  setIsReconcilable: Dispatch<SetStateAction<boolean>>;
+  setUnreconciledEntries: Dispatch<SetStateAction<IntegrationTransactionEntry[]>>;
+  transaction: TransactionProps;
   unreconciledEntries: IntegrationTransactionEntry[];
-  removeEntry: (entry: string) => void;
-  addEntry: (entry: string) => void;
 }
 
 export const ReconciliationTransactionEntries = (props: Props): React.JSX.Element => {
-  const [entriesSource, setEntriesSource] = useState(ReconciliationEntrySources.Match);
-  const propsWithSource = { ...props, entriesSource }
+  const { transaction, unreconciledEntries } = props;
+
+  const matchingEntries = unreconciledEntries.filter(
+    entry => entry.integrationTransactionLabel === transaction.atomicTransactionId
+  );
+
+  const defaultEntriesSource = matchingEntries.length > 0
+    ? ReconciliationEntrySources.Match
+    : ReconciliationEntrySources.Pick;
+
+  const [entriesSource, setEntriesSource] = useState(defaultEntriesSource);
+  const selectorProps = { ...props, entriesSource, matchingEntries };
 
   return (
     <div className="mx-2 p-4">
@@ -23,7 +33,7 @@ export const ReconciliationTransactionEntries = (props: Props): React.JSX.Elemen
         entriesSource={entriesSource}
         setEntriesSource={setEntriesSource}
       />
-      <EntriesSelector { ...propsWithSource } />
+      <EntriesSelector {...selectorProps} />
     </div>
   );
 };

--- a/src/components/reports/create/reconciliation/UnreconciledEntries.tsx
+++ b/src/components/reports/create/reconciliation/UnreconciledEntries.tsx
@@ -8,8 +8,8 @@ interface Props {
 
 export const UnreconciledEntries = ({ entries, moveEntry }: Props): React.JSX.Element => {
   return (
-    <div className="flex-1 border border-gray-500 p-4">
-      <h5 className="pb-4">Entries from integration not yet reconciled</h5>
+    <div className="flex-1 border border-gray-500 px-4 py-2">
+      <h5 className="pb-4">{entries.length} entries from integration not yet reconciled</h5>
       <ul className="w-full divide-y-4">
         {entries.length ?
           entries.map((entry) =>

--- a/src/components/reports/reconciliation/Reconciliation.tsx
+++ b/src/components/reports/reconciliation/Reconciliation.tsx
@@ -1,23 +1,15 @@
-import { IntegrationTransactionEntry, ReconciledTransaction } from "@/services/reports/reconciliation"
+import { ReconciledTransaction } from "@/services/reports/reconciliation"
 import { ChainTransactionForReconciliation } from "./ChainTransactionForReconciliation";
 import { ReconciliationEntry } from "./ReconciliationEntry";
-import { parseAmount } from "@/lib/helpers";
+import { calculateTransactionAmount, sumEntryAmounts } from "@/lib/helpers";
 
 interface Props {
   reconciliation: ReconciledTransaction;
 }
 
 export const Reconciliation = ({ reconciliation }: Props): React.JSX.Element => {
-  // This is repeated from the ReconciliationTransaction component
-  // TODO: make it not be repeated
-  const amountIncoming = parseAmount(reconciliation.transaction.amountIncoming);
-  const amountOutgoing = parseAmount(reconciliation.transaction.amountOutgoing);
-  const transactionAmount = Math.abs(amountIncoming - amountOutgoing);
-
-  const sumAmounts = (total: number, entry: IntegrationTransactionEntry): number =>
-    total + parseAmount(entry.reconvertedAmount);
-
-  const entriesAmount = reconciliation.matchingEntries.reduce(sumAmounts, 0);
+  const transactionAmount = calculateTransactionAmount(reconciliation.transaction);
+  const entriesAmount = sumEntryAmounts(reconciliation.matchingEntries)
   const excessAmountInTransaction = transactionAmount - entriesAmount;
   const excessPercentage = Math.abs(100 * excessAmountInTransaction / transactionAmount)
 

--- a/src/components/reports/reconciliation/ReconciliationEntry.tsx
+++ b/src/components/reports/reconciliation/ReconciliationEntry.tsx
@@ -10,14 +10,15 @@ interface Props {
 
 export const ReconciliationEntry = ({ entry, moveEntry, buttonText }: Props): React.JSX.Element => {
   const placeholderAmount = `${entry.amountFromIntegration} ${entry.currency}`;
+  const currency = entry.cryptoToken ? symbolFormatTransaction(entry.cryptoToken) : "¤";
 
   return (
     <li className="block mb-2">
       <div className="flex justify-between">
         <div>
           <p>On {entry.accountingDate} to account: {entry.integrationAccountName} (#{entry.integrationAccountId})</p>
-          <p>{entry.direction} amount: {entry.reconvertedAmount} {symbolFormatTransaction(entry.cryptoToken)} ({placeholderAmount})</p>
-          <p>Ref: {entry.integrationTransactionLabel || '(none)'}</p>
+          <p>{entry.direction} amount: {entry.reconvertedAmount} {currency} ({placeholderAmount})</p>
+          <p>Crypto transaction: {entry.integrationTransactionLabel || '(none)'}</p>
           <p className="text-sm">Entered into integration at {entry.createdAt}</p>
         </div>
         <button

--- a/src/hooks/reports/usePickEntries.ts
+++ b/src/hooks/reports/usePickEntries.ts
@@ -1,0 +1,77 @@
+import { calculateTransactionAmount } from "@/lib/helpers";
+import { IntegrationTransactionEntry } from "@/services/reports/reconciliation";
+import { Direction, TransactionProps } from "@/services/transactions";
+import { Dispatch, SetStateAction, useCallback, useState } from "react";
+
+interface Props {
+  setIsReconcilable: Dispatch<SetStateAction<boolean>>;
+  setUnreconciledEntries: Dispatch<SetStateAction<IntegrationTransactionEntry[]>>;
+  transaction: TransactionProps;
+  unreconciledEntries: IntegrationTransactionEntry[];
+}
+
+interface ReturnProps {
+  checkIfReconcilable: () => void;
+  pickedEntries: IntegrationTransactionEntry[];
+  pickedEntriesAmount: number;
+  pickEntry: (clickedEntryId: string) => void;
+  setPickedEntriesAmount: Dispatch<SetStateAction<number>>;
+  unpickEntry: (clickedEntryId: string) => void;
+}
+
+export const usePickEntries = ({
+  setIsReconcilable,
+  setUnreconciledEntries,
+  transaction,
+  unreconciledEntries,
+}: Props): ReturnProps => {
+  const [pickedEntries, setPickedEntries] = useState([] as IntegrationTransactionEntry[]);
+  const [pickedEntriesAmount, setPickedEntriesAmount] = useState(0.0);
+
+  const pickEntry = (clickedEntryId: string): void => {
+    const clickedEntry = unreconciledEntries.find(
+      entry => entry.entryId === clickedEntryId
+    ) as IntegrationTransactionEntry;
+    setUnreconciledEntries(unreconciledEntries.filter(entry => entry !== clickedEntry));
+    setPickedEntries(pickedEntries.concat(clickedEntry));
+  };
+
+  const unpickEntry = (clickedEntryId: string): void => {
+    const clickedEntry = pickedEntries.find(
+      entry => entry.entryId === clickedEntryId
+    ) as IntegrationTransactionEntry;
+
+    setUnreconciledEntries(unreconciledEntries.concat(clickedEntry));
+    setPickedEntries(pickedEntries.filter(entry => entry !== clickedEntry));
+  }
+
+  const checkIfReconcilableCallback = (): void => {
+    const transactionAmount = calculateTransactionAmount(transaction);
+    const tolerance = 0.05;
+    const isDiscrepancyTolerable = Math.abs(
+      (transactionAmount - pickedEntriesAmount) / transactionAmount
+    ) <= tolerance;
+
+    if ([Direction.Incoming, Direction.Outgoing].includes(transaction.direction)) {
+      setIsReconcilable(isDiscrepancyTolerable);
+    } else {
+      const hasIncoming = pickedEntries.some(entry => entry.direction === Direction.Incoming);
+      const hasOutgoing = pickedEntries.some(entry => entry.direction === Direction.Outgoing);
+      setIsReconcilable(isDiscrepancyTolerable && hasIncoming && hasOutgoing);
+    }
+  };
+
+  const checkIfReconcilable = useCallback(
+    checkIfReconcilableCallback,
+    [pickedEntries, pickedEntriesAmount, setIsReconcilable, transaction],
+  );
+
+  return {
+    checkIfReconcilable,
+    pickedEntries,
+    pickedEntriesAmount,
+    pickEntry,
+    setPickedEntriesAmount,
+    unpickEntry,
+  };
+};

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,4 +1,6 @@
 import { Token } from "@/services/token_currencies_conversions";
+import { TransactionProps } from "@/services/transactions";
+import { IntegrationTransactionEntry } from "@/services/reports/reconciliation";
 
 
 const tooltipFormatterStellar = (token: Token): string => {
@@ -40,6 +42,19 @@ const keyFormatters: Record<string, (token: Token) => string> = {
 export const keyFormatTransaction = (token: Token): string => {
     return keyFormatters[token.chain](token);
 };
+
+export const calculateTransactionAmount = (transaction: TransactionProps): number => {
+  const amountIncoming = parseAmount(transaction.amountIncoming);
+  const amountOutgoing = parseAmount(transaction.amountOutgoing);
+  return Math.abs(amountIncoming - amountOutgoing);
+}
+
+export const sumEntryAmounts = (entries: IntegrationTransactionEntry[]): number =>
+  entries.reduce(
+    (total: number, entry: IntegrationTransactionEntry): number =>
+      total + parseAmount(entry.reconvertedAmount),
+    0.0
+  );
 
 export const parseAmount = (amount: string): number => {
     const parsed = parseFloat(amount);

--- a/src/services/reports/reconciliation.ts
+++ b/src/services/reports/reconciliation.ts
@@ -85,6 +85,7 @@ export const getIntegrationEntries = async (): Promise<GetIntegrationEntriesAPIR
   const { data } = await apiClient.post("/integration-entries/list", {
     integrationProvider: "QuickBooks",
   });
+
   return data;
 };
 


### PR DESCRIPTION
It is convenient for the user if the entries that are known to correspond to a crypto transaction are recommended for easy reconciliation. We implement that recommendation system.